### PR TITLE
Add map property type

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,8 +1,9 @@
 [
   line_length: 130,
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test,test_lib}/**/*.{ex,exs}"],
   locals_without_parens: [
     additional_properties: 1,
+    additional_properties: 2,
     open_api_object: 1,
     open_api_object: 2,
     open_api_object: 3,

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ defmodule Employee do
     property :level, :string, enum: ["L1", "L2", "L3"]
     property :experience, [:number, :string]
     property :is_manager, :boolean, default: false
-    property :known_technologies, {:array, :string}, nullable: true
+    property :team_members, {:array, Employee}, nullable: true
+    property :technologies_to_experience, {:map, :string}
     additional_properties :integer
   end
 end
@@ -25,8 +26,9 @@ Other properties in the `Employee` schema:
 * `:level` - it has type `:string` and can be one of `["L1", "L2", "L3"]`
 * `:experience` - its type is a union of `:number` and `:string`
 * `:is_manager` - it has type `:boolean` and is `false` by default
-* `:known_technologies` - its type is an array with strings or `nil`
-* `additional_properties` - it can have more properties having type `:integer`
+* `:team_members` - its type is an array with employees or `nil`
+* `:technologies_to_experience` - its type is an object with additional properties having type `:string`
+* `additional_properties` - the schema can have more properties having type `:integer`
 
 All properties are required and not nullable by default.
 
@@ -40,7 +42,8 @@ Also, the following typespec will be created:
   level: String.t(),
   experience: number() | String.t(),
   is_manager: boolean(),
-  known_technologies: [:String.t()] | nil
+  team_members: [t()] | nil,
+  technologies_to_experience: %{optional(String.t()) => String.t()},
   ... # and all properties from Person
 }
 ```

--- a/test/jungle_spec/type_generator_test.exs
+++ b/test/jungle_spec/type_generator_test.exs
@@ -53,6 +53,24 @@ defmodule JungleSpec.TypespecGeneratorTest do
       assert generate_type(schema, [], []) == type
     end
 
+    test "map type" do
+      schema = %Schema{
+        title: "Example",
+        type: :object,
+        nullable: false,
+        properties: %{
+          map: %Schema{type: :object, additionalProperties: %Schema{type: :number, nullable: false}}
+        }
+      }
+
+      type =
+        quote do
+          %{map: %{optional(String.t()) => number()}}
+        end
+
+      assert generate_type(schema, [], []) == type
+    end
+
     test "union type" do
       schema = %Schema{
         title: "Example",
@@ -313,7 +331,7 @@ defmodule JungleSpec.TypespecGeneratorTest do
         title: "Example",
         oneOf: [
           %Schema{type: :array, items: %Schema{type: :integer, nullable: true}, nullable: true},
-          %Schema{type: :boolean, nullable: false},
+          %Schema{type: :object, additionalProperties: %Schema{type: :boolean, nullable: false}},
           %OpenApiSpex.Reference{"$ref": reference}
         ],
         nullable: true
@@ -321,7 +339,7 @@ defmodule JungleSpec.TypespecGeneratorTest do
 
       type =
         quote do
-          [integer() | nil] | boolean() | JungleSpec.TypespecGeneratorTest.ExampleModule.t() | nil
+          [integer() | nil] | %{optional(String.t()) => boolean()} | JungleSpec.TypespecGeneratorTest.ExampleModule.t() | nil
         end
 
       references_to_modules = [{reference, JungleSpec.TypespecGeneratorTest.ExampleModule}]

--- a/test_lib/student_jungle.ex
+++ b/test_lib/student_jungle.ex
@@ -5,5 +5,6 @@ defmodule StudentJungle do
     property :degree_type, :string, enum: ["bachelor's", "master's"]
     property :university, UniversityJungle, inline: true
     property :grades, {:array, [:number, :string]}, required: false, nullable: true
+    property :assignments, {:map, {:array, :string}}, description: "Assignemnts per subject", nullable: true
   end
 end

--- a/test_lib/student_spex.ex
+++ b/test_lib/student_spex.ex
@@ -12,7 +12,8 @@ defmodule StudentSpex do
         PersonSpex.schema().required ++
           [
             :degree_type,
-            :university
+            :university,
+            :assignments
           ],
       properties:
         Map.merge(
@@ -34,6 +35,13 @@ defmodule StudentSpex do
                 ],
                 nullable: false
               }
+            },
+            assignments: %Schema{
+              type: :object,
+              nullable: true,
+              properties: %{},
+              additionalProperties: %Schema{type: :array, items: %Schema{type: :string, nullable: false}, nullable: false},
+              description: "Assignemnts per subject"
             }
           }
         )


### PR DESCRIPTION
Adds a new property type `:map` mentioned in [this](https://github.com/Qarma-inspect/jungle-spec/issues/4) issue.
- It has to be used through tuple `{:map, type}`, similarly to `:array` type. 
- `:map` type creates an object without properties but having additional properties with the provided type. Thus, we can treat it as a dictionary.
- It also works with `open_api_type`.