### PR TITLE
Validate macro options against an explicit contract

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
-locals_without_parens =  [
+locals_without_parens = [
   additional_properties: 1,
   additional_properties: 2,
   open_api_object: 1,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.2.0
+
+**Breaking.** Options given to `open_api_object/3`, `open_api_type/3`, `property/3` and
+`additional_properties/2` are now validated while the schema is compiled. Keys that were
+previously accepted and silently discarded now raise an `ArgumentError`.
+
+* The set of accepted options is derived from `OpenApiSpex.Schema` instead of a hardcoded list, so
+  the schema fields JungleSpec does not set itself now reach the generated schema. That includes
+  the validation keywords (`minimum`, `maximum`, `minLength`, `minItems`, `uniqueItems` and the
+  rest) and the documentation keywords (`deprecated`, `readOnly`, `writeOnly`, `externalDocs`).
+  Module-typed properties are the exception: a bare `$ref` has nowhere to put them, so only
+  `:nullable` and `:inline` take effect there.
+* Unknown options raise, with a suggestion of the closest supported option.
+* Options that JungleSpec sets itself (`type`, `items`, `oneOf`, `title` and friends) raise
+  instead of being ignored.
+* Options are rejected for types they do not apply to, for example `minimum` on a `:string`, or
+  `format` on a union.
+* Options describing a single value now apply to the items of a collection. `{:array, type}` and
+  `{:map, type}` accept whatever `type` accepts and hand it to the item schema, so
+  `property :ids, {:array, :string}, format: :uuid, minItems: 1` puts `minItems` on the array and
+  `format` on its items. Every other option describes the schema it is given for: previously keys
+  such as `example` ended up on the item schema instead of the container.
+* Object level options are validated the same way property level ones are. An `enum` raises,
+  since it needs a `:string` type, and a `default` has to be a map.
+
+Unrelated to the above, and not breaking:
+
+* `open_api_type/2`, `property/2` and `additional_properties/1` are now imported by `use
+  JungleSpec`. `open_api_type "Title", :string` previously failed with `undefined function
+  open_api_type/2` and needed an explicit empty option list; the other two were reachable only
+  inside an `open_api_object` block, which imports the module unrestricted.
+
 ## 0.1.1
 
 * Update `open_api_spex` dependency to `~> 3.21`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ previously accepted and silently discarded now raise an `ArgumentError`.
   `property :ids, {:array, :string}, format: :uuid, minItems: 1` puts `minItems` on the array and
   `format` on its items. Every other option describes the schema it is given for: previously keys
   such as `example` ended up on the item schema instead of the container.
+* An `enum` is accepted for `:integer` and `:number` as well as `:string`; its values have to
+  match the type they are given for. It used to be rejected for anything but `:string`.
 * Object level options are validated the same way property level ones are. An `enum` raises,
-  since it needs a `:string` type, and a `default` has to be a map.
+  since an object is not a scalar, and a `default` has to be a map.
 
 Unrelated to the above, and not breaking:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ previously accepted and silently discarded now raise an `ArgumentError`.
   rest) and the documentation keywords (`deprecated`, `readOnly`, `writeOnly`, `externalDocs`).
   Module-typed properties are the exception: a bare `$ref` has nowhere to put them, so only
   `:nullable` and `:inline` take effect there.
+* Options are named the way Elixir names things and are translated to the camelCased field they
+  set, so the `minLength` field of `OpenApiSpex.Schema` is given as `min_length` and `x-validate`
+  as `x_validate`. Only the snake_cased form is accepted.
 * Unknown options raise, with a suggestion of the closest supported option.
 * Options that JungleSpec sets itself (`type`, `items`, `oneOf`, `title` and friends) raise
   instead of being ignored.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ previously accepted and silently discarded now raise an `ArgumentError`.
 
 * The set of accepted options is derived from `OpenApiSpex.Schema` instead of a hardcoded list, so
   the schema fields JungleSpec does not set itself now reach the generated schema. That includes
-  the validation keywords (`minimum`, `maximum`, `minLength`, `minItems`, `uniqueItems` and the
-  rest) and the documentation keywords (`deprecated`, `readOnly`, `writeOnly`, `externalDocs`).
+  the validation keywords (`minimum`, `maximum`, `min_length`, `min_items`, `unique_items` and
+  the rest) and the documentation keywords (`deprecated`, `read_only`, `write_only`,
+  `external_docs`).
   Module-typed properties are the exception: a bare `$ref` has nowhere to put them, so only
   `:nullable` and `:inline` take effect there.
 * Options are named the way Elixir names things and are translated to the camelCased field they
@@ -22,8 +23,8 @@ previously accepted and silently discarded now raise an `ArgumentError`.
   `format` on a union.
 * Options describing a single value now apply to the items of a collection. `{:array, type}` and
   `{:map, type}` accept whatever `type` accepts and hand it to the item schema, so
-  `property :ids, {:array, :string}, format: :uuid, minItems: 1` puts `minItems` on the array and
-  `format` on its items. Every other option describes the schema it is given for: previously keys
+  `property :ids, {:array, :string}, format: :uuid, min_items: 1` puts `min_items` on the array
+  and `format` on its items. Every other option describes the schema it is given for: previously keys
   such as `example` ended up on the item schema instead of the container.
 * An `enum` is accepted for `:integer` and `:number` as well as `:string`; its values have to
   match the type they are given for. It used to be rejected for anything but `:string`.

--- a/lib/jungle_spec.ex
+++ b/lib/jungle_spec.ex
@@ -223,11 +223,12 @@ defmodule JungleSpec do
   @object_only_opts @object_opts -- @property_opts
 
   @numeric_types [:integer, :number]
+  @enum_types [:integer, :number, :string]
 
   # Options that only make sense for a given kind of value. For a collection they describe its
   # items, which is why `{:array, type}` and `{:map, type}` also accept the ones valid for `type`.
-  @numeric_opts [:exclusiveMaximum, :exclusiveMinimum, :format, :maximum, :minimum, :multipleOf]
-  @string_opts [:format, :maxLength, :minLength, :pattern]
+  @numeric_opts [:enum, :exclusiveMaximum, :exclusiveMinimum, :format, :maximum, :minimum, :multipleOf]
+  @string_opts [:enum, :format, :maxLength, :minLength, :pattern]
   @array_opts [:maxItems, :minItems, :uniqueItems]
   @map_opts [:maxProperties, :minProperties]
   @item_opts Enum.uniq(@numeric_opts ++ @string_opts)
@@ -441,18 +442,17 @@ defmodule JungleSpec do
 
   Some options only apply to certain types, and are rejected elsewhere:
 
-    * `:format`, `:minimum`, `:maximum`, `:exclusiveMinimum`, `:exclusiveMaximum` and
+    * `:enum`, `:format`, `:minimum`, `:maximum`, `:exclusiveMinimum`, `:exclusiveMaximum` and
       `:multipleOf` on `:integer` and `:number`. Note that `OpenApiSpex` does not enforce
       `:multipleOf` for `:number`, so it reaches the document but is not checked while casting
 
-    * `:format`, `:minLength`, `:maxLength` and `:pattern` on `:string`
+    * `:enum`, `:format`, `:minLength`, `:maxLength` and `:pattern` on `:string`
 
     * `:minItems`, `:maxItems` and `:uniqueItems` on `{:array, type}`
 
     * `:minProperties` and `:maxProperties` on `{:map, type}` and on objects
 
-  `:enum` is valid only for `:string` and its values have to be binaries. A `:default` has to
-  match the type it is given for.
+  The values of an `:enum` have to match the type it is given for, and so does a `:default`.
 
   An option describing a single value applies to the items of a collection, so `{:array, type}`
   and `{:map, type}` additionally accept whatever `type` accepts and hand it to the item schema:
@@ -735,17 +735,20 @@ defmodule JungleSpec do
     Enum.filter(list_allowed_opts(type), &(&1 in @item_opts))
   end
 
-  defp validate_enum!(name, type, opts) do
+  # Which types accept an enum at all is decided by `list_allowed_opts/1`; for a collection the
+  # nested schema validates the values against the item type.
+  defp validate_enum!(name, type, opts) when type in @enum_types do
     if Keyword.has_key?(opts, :enum) do
-      if type != :string do
-        raise ArgumentError,
-              "#{name} has an enum option, but it can be provided only for string type"
-      end
+      values = Keyword.get(opts, :enum)
+      validate_enum_values!(name, type, values)
+    end
+  end
 
-      if opts |> Keyword.get(:enum) |> Enum.any?(fn item -> not is_binary(item) end) do
-        raise ArgumentError,
-              "#{name} has values of invalid types in the enum option. They should be binaries"
-      end
+  defp validate_enum!(_name, _type, _opts), do: :ok
+
+  defp validate_enum_values!(name, type, values) do
+    if Enum.any?(values, &(not has_valid_type?(&1, type))) do
+      raise ArgumentError, "the enum values of #{name} do not all match its type #{inspect(type)}"
     end
   end
 

--- a/lib/jungle_spec.ex
+++ b/lib/jungle_spec.ex
@@ -195,7 +195,13 @@ defmodule JungleSpec do
         }
   """
 
+  alias JungleSpec.OptionName
   alias OpenApiSpex.Schema
+
+  # Options are named the way Elixir names things and translated to the camelCased schema field
+  # they set, so the `minLength` field of `OpenApiSpex.Schema` is given as `min_length`.
+  @field_by_option Map.new(Map.keys(Map.from_struct(%Schema{})), &{OptionName.to_option(&1), &1})
+  @option_names Map.keys(@field_by_option)
 
   # Options interpreted by JungleSpec itself. They never reach the generated schema struct as
   # given: `:extends` and `:struct?` shape the module, `:inline` picks reference vs inlining, and
@@ -205,19 +211,18 @@ defmodule JungleSpec do
   # Schema fields JungleSpec derives from the positional type argument. Accepting them as options
   # would let a caller silently overwrite what the macro already decided.
   @derived_schema_fields [
-    :additionalProperties,
-    :allOf,
-    :anyOf,
+    :additional_properties,
+    :all_of,
+    :any_of,
     :items,
-    :oneOf,
+    :one_of,
     :properties,
     :title,
     :type,
-    :"x-struct"
+    :x_struct
   ]
 
-  @schema_fields Map.keys(Map.from_struct(%Schema{}))
-  @passthrough_opts @schema_fields -- (@derived_schema_fields ++ @jungle_spec_opts)
+  @passthrough_opts @option_names -- (@derived_schema_fields ++ @jungle_spec_opts)
   @object_opts @passthrough_opts ++ @jungle_spec_opts
   @property_opts @passthrough_opts ++ [:inline, :nullable, :required]
   @object_only_opts @object_opts -- @property_opts
@@ -227,10 +232,10 @@ defmodule JungleSpec do
 
   # Options that only make sense for a given kind of value. For a collection they describe its
   # items, which is why `{:array, type}` and `{:map, type}` also accept the ones valid for `type`.
-  @numeric_opts [:enum, :exclusiveMaximum, :exclusiveMinimum, :format, :maximum, :minimum, :multipleOf]
-  @string_opts [:enum, :format, :maxLength, :minLength, :pattern]
-  @array_opts [:maxItems, :minItems, :uniqueItems]
-  @map_opts [:maxProperties, :minProperties]
+  @numeric_opts [:enum, :exclusive_maximum, :exclusive_minimum, :format, :maximum, :minimum, :multiple_of]
+  @string_opts [:enum, :format, :max_length, :min_length, :pattern]
+  @array_opts [:max_items, :min_items, :unique_items]
+  @map_opts [:max_properties, :min_properties]
   @item_opts Enum.uniq(@numeric_opts ++ @string_opts)
   @type_scoped_opts Enum.uniq(@item_opts ++ @array_opts ++ @map_opts)
 
@@ -289,9 +294,9 @@ defmodule JungleSpec do
 
   Besides those, every field of `OpenApiSpex.Schema` that JungleSpec does not derive itself is
   copied into the object's schema, and any other key raises an `ArgumentError`. Options are
-  validated exactly as in `property/3`, against the object type: `:minProperties`, `:maxProperties`
-  and a map-valued `:default` are accepted, while `:enum` and the options describing a single
-  value, such as `:format` or `:minLength`, are rejected. See `property/3` for the full contract.
+  validated exactly as in `property/3`, against the object type: `:min_properties`,
+  `:max_properties` and a map-valued `:default` are accepted, while `:enum` and the options
+  describing a single value, such as `:format` or `:min_length`, are rejected. See `property/3` for the full contract.
   """
   defmacro open_api_object(title, opts, do: block) do
     quote do
@@ -414,6 +419,9 @@ defmodule JungleSpec do
 
   Property also has an optional keyword list of options.
 
+  Options are named the way Elixir names things and are translated to the camelCased field they
+  set, so the `minLength` field of `OpenApiSpex.Schema` is given as `min_length`.
+
   Options fall into three groups:
 
     * `:inline`, `:nullable` and `:required` are interpreted by JungleSpec itself:
@@ -430,38 +438,38 @@ defmodule JungleSpec do
     * every remaining field of `OpenApiSpex.Schema` is copied into the generated schema as it is
       given. That covers `:default`, `:description`, `:enum`, `:example`, `:format`, `:pattern`,
       the validation keywords listed below, and documentation keywords such as `:deprecated`,
-      `:readOnly`, `:writeOnly` and `:externalDocs`. A property typed by another module is the
+      `:read_only`, `:write_only` and `:external_docs`. A property typed by another module is the
       exception: it renders as a bare `$ref`, which has nowhere to carry them, so only `:nullable`
       and `:inline` take effect there
 
     * the fields JungleSpec derives from the type argument cannot be given: `:type`, `:title`,
-      `:properties`, `:items`, `:additionalProperties`, `:oneOf`, `:allOf`, `:anyOf` and
-      `:"x-struct"`
+      `:properties`, `:items`, `:additional_properties`, `:one_of`, `:all_of`, `:any_of` and
+      `:x_struct`
 
   Any other key raises an `ArgumentError` while the schema is being compiled.
 
   Some options only apply to certain types, and are rejected elsewhere:
 
-    * `:enum`, `:format`, `:minimum`, `:maximum`, `:exclusiveMinimum`, `:exclusiveMaximum` and
-      `:multipleOf` on `:integer` and `:number`. Note that `OpenApiSpex` does not enforce
-      `:multipleOf` for `:number`, so it reaches the document but is not checked while casting
+    * `:enum`, `:format`, `:minimum`, `:maximum`, `:exclusive_minimum`, `:exclusive_maximum` and
+      `:multiple_of` on `:integer` and `:number`. Note that `OpenApiSpex` does not enforce
+      `:multiple_of` for `:number`, so it reaches the document but is not checked while casting
 
-    * `:enum`, `:format`, `:minLength`, `:maxLength` and `:pattern` on `:string`
+    * `:enum`, `:format`, `:min_length`, `:max_length` and `:pattern` on `:string`
 
-    * `:minItems`, `:maxItems` and `:uniqueItems` on `{:array, type}`
+    * `:min_items`, `:max_items` and `:unique_items` on `{:array, type}`
 
-    * `:minProperties` and `:maxProperties` on `{:map, type}` and on objects
+    * `:min_properties` and `:max_properties` on `{:map, type}` and on objects
 
   The values of an `:enum` have to match the type it is given for, and so does a `:default`.
 
   An option describing a single value applies to the items of a collection, so `{:array, type}`
   and `{:map, type}` additionally accept whatever `type` accepts and hand it to the item schema:
 
-      property :ids, {:array, :string}, format: :uuid, minItems: 1
+      property :ids, {:array, :string}, format: :uuid, min_items: 1
 
-  puts `minItems` on the array and `format` on its items. Only options describing a single value
+  puts `min_items` on the array and `format` on its items. Only options describing a single value
   travel that way, so a collection nested in another collection cannot be constrained from the
-  outside: `{:array, {:map, :string}}` rejects `:minProperties`. A union has no single item to
+  outside: `{:array, {:map, :string}}` rejects `:min_properties`. A union has no single item to
   describe and rejects item options as well. Every other option describes the schema it is given
   for and is never passed down; `:inline` travels to the items too, since it decides how a
   module-typed item is rendered.
@@ -813,14 +821,16 @@ defmodule JungleSpec do
     schema_map
   end
 
-  defp maybe_add_opts(schema_map, keys, opts) do
-    Enum.reduce(keys, schema_map, fn key, map ->
-      if Keyword.has_key?(opts, key) do
-        Map.put(map, key, Keyword.get(opts, key))
-      else
-        map
-      end
-    end)
+  defp maybe_add_opts(schema_map, options, opts) do
+    Enum.reduce(options, schema_map, &put_given_option(&1, &2, opts))
+  end
+
+  defp put_given_option(option, schema_map, opts) do
+    if Keyword.has_key?(opts, option) do
+      Map.put(schema_map, Map.fetch!(@field_by_option, option), Keyword.get(opts, option))
+    else
+      schema_map
+    end
   end
 
   defp maybe_add_xstruct(schema, module, opts) do

--- a/lib/jungle_spec.ex
+++ b/lib/jungle_spec.ex
@@ -269,10 +269,6 @@ defmodule JungleSpec do
 
   Possible options
 
-    * `:description` - a binary describing the whole object
-
-    * `:example` - a map being an example of the object defined by the schema
-
     * `:extends` - a module of the schema that this schema extends. All properties of the extended
       schema will be added to the current schema, preserving the information if the properties are
       required. It does not propagate nullability of the extended schema. Ensure that
@@ -367,8 +363,8 @@ defmodule JungleSpec do
 
     * `module` - a module name that has it's own schema.
 
-  The options are the ones accepted by `property/3`, except for `:extends` and `:struct?`,
-  which only `open_api_object/3` supports.
+  The options are the ones accepted by `property/3`. `:extends` and `:struct?` are supported only
+  by `open_api_object/3` and raise here.
   """
   defmacro open_api_type(title, type, opts \\ []) do
     quote do

--- a/lib/jungle_spec.ex
+++ b/lib/jungle_spec.ex
@@ -673,7 +673,9 @@ defmodule JungleSpec do
       key in known_opts ->
         :ok
 
-      key in @derived_schema_fields ->
+      # The camelCased spelling is matched too, so that a schema field JungleSpec sets is reported
+      # as such however it was written.
+      key in @derived_schema_fields or OptionName.to_option(key) in @derived_schema_fields ->
         raise ArgumentError,
               "#{inspect(key)} cannot be given as an option for #{name}: JungleSpec sets it itself"
 

--- a/lib/jungle_spec.ex
+++ b/lib/jungle_spec.ex
@@ -244,11 +244,14 @@ defmodule JungleSpec do
     quote do
       import JungleSpec,
         only: [
+          additional_properties: 1,
           additional_properties: 2,
           open_api_object: 1,
           open_api_object: 2,
           open_api_object: 3,
+          open_api_type: 2,
           open_api_type: 3,
+          property: 2,
           property: 3
         ]
     end

--- a/lib/jungle_spec.ex
+++ b/lib/jungle_spec.ex
@@ -197,6 +197,49 @@ defmodule JungleSpec do
 
   alias OpenApiSpex.Schema
 
+  # Options interpreted by JungleSpec itself. They never reach the generated schema struct as
+  # given: `:extends` and `:struct?` shape the module, `:inline` picks reference vs inlining, and
+  # `:nullable`/`:required` are placed by each type clause.
+  @jungle_spec_opts [:extends, :inline, :nullable, :required, :struct?]
+
+  # Schema fields JungleSpec derives from the positional type argument. Accepting them as options
+  # would let a caller silently overwrite what the macro already decided.
+  @derived_schema_fields [
+    :additionalProperties,
+    :allOf,
+    :anyOf,
+    :items,
+    :oneOf,
+    :properties,
+    :title,
+    :type,
+    :"x-struct"
+  ]
+
+  @schema_fields Map.keys(Map.from_struct(%Schema{}))
+  @passthrough_opts @schema_fields -- (@derived_schema_fields ++ @jungle_spec_opts)
+  @object_opts @passthrough_opts ++ @jungle_spec_opts
+  @property_opts @passthrough_opts ++ [:inline, :nullable, :required]
+  @object_only_opts @object_opts -- @property_opts
+
+  @numeric_types [:integer, :number]
+
+  # Options that only make sense for a given kind of value. For a collection they describe its
+  # items, which is why `{:array, type}` and `{:map, type}` also accept the ones valid for `type`.
+  @numeric_opts [:exclusiveMaximum, :exclusiveMinimum, :format, :maximum, :minimum, :multipleOf]
+  @string_opts [:format, :maxLength, :minLength, :pattern]
+  @array_opts [:maxItems, :minItems, :uniqueItems]
+  @map_opts [:maxProperties, :minProperties]
+  @item_opts Enum.uniq(@numeric_opts ++ @string_opts)
+  @type_scoped_opts Enum.uniq(@item_opts ++ @array_opts ++ @map_opts)
+
+  # An option describing the items is handed to the nested schema; everything else stays on the
+  # container. `:inline` travels too, as it decides how a module-typed item is rendered.
+  @nested_opts [:inline | @item_opts]
+  @container_opts @passthrough_opts -- @item_opts
+
+  @suggestion_threshold 0.8
+
   defmacro __using__(_) do
     quote do
       import JungleSpec,
@@ -243,6 +286,12 @@ defmodule JungleSpec do
 
     * `:struct?` - a boolean value telling OpenApiSpex if it should create a struct out of the
       object. It will also add the struct to the typespec if set to `true`. By default it is `true`
+
+  Besides those, every field of `OpenApiSpex.Schema` that JungleSpec does not derive itself is
+  copied into the object's schema, and any other key raises an `ArgumentError`. Options are
+  validated exactly as in `property/3`, against the object type: `:minProperties`, `:maxProperties`
+  and a map-valued `:default` are accepted, while `:enum` and the options describing a single
+  value, such as `:format` or `:minLength`, are rejected. See `property/3` for the full contract.
   """
   defmacro open_api_object(title, opts, do: block) do
     quote do
@@ -315,25 +364,8 @@ defmodule JungleSpec do
 
     * `module` - a module name that has it's own schema.
 
-  Supported options are:
-
-    * `:default` - default value for the property. It has to match type of the property.
-
-    * `:description` - a binary describing the property.
-
-    * `:enum` - a list of possible values which have to be binaries. Only valid for `:string` type.
-
-    * `:example` - an example of the property. It has to match its type.
-
-    * `:format` - an atom describing property's format.
-
-    * `:inline` - a boolean value that is used if the property's type is another module. Then,
-      if `inline: true`, the module's schema is just inlined. Otherwise, only the reference is
-      used. By default, the value is propagated from the object.
-
-    * `:nullable` - a boolean value specifying if the property can be `nil`. `false` by default.
-
-    * `:pattern` - a regular expression describing possible format of the property. Only valid for `:string` type.
+  The options are the ones accepted by `property/3`, except for `:extends` and `:struct?`,
+  which only `open_api_object/3` supports.
   """
   defmacro open_api_type(title, type, opts \\ []) do
     quote do
@@ -380,29 +412,60 @@ defmodule JungleSpec do
 
     * `module` - a module name that has it's own schema
 
-  Property also has an optional keyword list with the following possible options:
+  Property also has an optional keyword list of options.
 
-    * `:default` - default value for the property. It has to match type of the property
+  Options fall into three groups:
 
-    * `:description` - a binary describing the property
+    * `:inline`, `:nullable` and `:required` are interpreted by JungleSpec itself:
 
-    * `:enum` - a list of possible values which have to be binaries. Also, property has to have
-      `:string` type
+      * `:inline` - a boolean value that is used if the type is another module. Then, if
+        `inline: true`, the module's schema is just inlined. Otherwise, only the reference is
+        used. By default, the value is propagated from the object
 
-    * `:example` - an example of the property. It has to match its type
+      * `:nullable` - a boolean value specifying if the value can be `nil`. `false` by default
 
-    * `:format` - an atom describing property's format
+      * `:required` - a boolean value specifying if the property should be added to the list of
+        object's required properties. By default, it is propagated from the object
 
-    * `:inline` - a boolean value that is used if the property's type is another module. Then,
-      if `inline: true`, the module's schema is just inlined. Otherwise, only the reference is
-      used. By default, the value is propagated from the object
+    * every remaining field of `OpenApiSpex.Schema` is copied into the generated schema as it is
+      given. That covers `:default`, `:description`, `:enum`, `:example`, `:format`, `:pattern`,
+      the validation keywords listed below, and documentation keywords such as `:deprecated`,
+      `:readOnly`, `:writeOnly` and `:externalDocs`. A property typed by another module is the
+      exception: it renders as a bare `$ref`, which has nowhere to carry them, so only `:nullable`
+      and `:inline` take effect there
 
-    * `:nullable` - a boolean value specifying if the property can be `nil`. `false` by default
+    * the fields JungleSpec derives from the type argument cannot be given: `:type`, `:title`,
+      `:properties`, `:items`, `:additionalProperties`, `:oneOf`, `:allOf`, `:anyOf` and
+      `:"x-struct"`
 
-    * `:pattern` - a regular expression describing possible format of the property
+  Any other key raises an `ArgumentError` while the schema is being compiled.
 
-    * `:required` - a boolean value specifying if the property should be added to the list of
-      object's required properties. By default, it is propagated from the object
+  Some options only apply to certain types, and are rejected elsewhere:
+
+    * `:format`, `:minimum`, `:maximum`, `:exclusiveMinimum`, `:exclusiveMaximum` and
+      `:multipleOf` on `:integer` and `:number`. Note that `OpenApiSpex` does not enforce
+      `:multipleOf` for `:number`, so it reaches the document but is not checked while casting
+
+    * `:format`, `:minLength`, `:maxLength` and `:pattern` on `:string`
+
+    * `:minItems`, `:maxItems` and `:uniqueItems` on `{:array, type}`
+
+    * `:minProperties` and `:maxProperties` on `{:map, type}` and on objects
+
+  `:enum` is valid only for `:string` and its values have to be binaries. A `:default` has to
+  match the type it is given for.
+
+  An option describing a single value applies to the items of a collection, so `{:array, type}`
+  and `{:map, type}` additionally accept whatever `type` accepts and hand it to the item schema:
+
+      property :ids, {:array, :string}, format: :uuid, minItems: 1
+
+  puts `minItems` on the array and `format` on its items. Only options describing a single value
+  travel that way, so a collection nested in another collection cannot be constrained from the
+  outside: `{:array, {:map, :string}}` rejects `:minProperties`. A union has no single item to
+  describe and rejects item options as well. Every other option describes the schema it is given
+  for and is never passed down; `:inline` travels to the items too, since it decides how a
+  module-typed item is rendered.
   """
   defmacro property(name, type, opts \\ []) do
     quote do
@@ -415,7 +478,8 @@ defmodule JungleSpec do
 
     * `type` - type have to be one of the allowed types defined in the `property` macro
 
-  It has also one option:
+  It takes the same options as `property/3`, validated against the given type, so an unknown or
+  inapplicable key raises an `ArgumentError`. The most common one is:
 
     * `:nullable` - a boolean value specifying if the additional properties can be nullable.
     `false` by default
@@ -429,7 +493,7 @@ defmodule JungleSpec do
   def prepare_object_schema(module, title, properties, additional_properties, opts) do
     properties = propagate_general_opts(properties, opts)
 
-    validate_object_opts!(properties, additional_properties, opts)
+    validate_object_opts!(title, properties, additional_properties, opts)
 
     nullable = Keyword.get(opts, :nullable, false)
 
@@ -449,7 +513,7 @@ defmodule JungleSpec do
         type: :object
       }
       |> maybe_add_additional_properties(module, title, additional_properties)
-      |> maybe_add_opts([:description, :example], opts)
+      |> maybe_add_opts(@passthrough_opts, opts)
       |> maybe_add_xstruct(module, opts)
       |> maybe_extend_object(opts)
 
@@ -471,7 +535,12 @@ defmodule JungleSpec do
     end)
   end
 
-  defp validate_object_opts!(properties, additional_properties, object_opts) do
+  defp validate_object_opts!(title, properties, additional_properties, object_opts) do
+    validate_known_opts!(title, object_opts, @object_opts)
+    validate_type_scoped_opts!(title, :object, object_opts)
+    validate_enum!(title, :object, object_opts)
+    validate_default!(title, :object, object_opts)
+
     struct? = Keyword.get(object_opts, :struct?, true)
 
     if struct? and not is_nil(additional_properties) do
@@ -493,16 +562,12 @@ defmodule JungleSpec do
   defp prepare_property_schema(module, title, name, {:array, type}, opts) do
     validate_opts!(name, {:array, type}, opts)
 
-    items_schema = prepare_property_schema(module, title, name, type, clear_opts_for_nested_types(opts))
+    items_schema = prepare_property_schema(module, title, name, type, keep_opts_for_nested_types(opts))
 
     nullable = Keyword.get(opts, :nullable, false)
 
     schema_map =
-      maybe_add_opts(
-        %{type: :array, items: items_schema, nullable: nullable},
-        [:description, :default],
-        opts
-      )
+      maybe_add_opts(%{type: :array, items: items_schema, nullable: nullable}, @container_opts, opts)
 
     struct(Schema, schema_map)
   end
@@ -510,14 +575,14 @@ defmodule JungleSpec do
   defp prepare_property_schema(module, title, name, {:map, type}, opts) do
     validate_opts!(name, {:map, type}, opts)
 
-    nested_properties_schema = prepare_property_schema(module, title, name, type, clear_opts_for_nested_types(opts))
+    nested_properties_schema = prepare_property_schema(module, title, name, type, keep_opts_for_nested_types(opts))
 
     nullable = Keyword.get(opts, :nullable, false)
 
     schema_map =
       maybe_add_opts(
         %{type: :object, properties: %{}, additionalProperties: nested_properties_schema, nullable: nullable},
-        [:description, :default],
+        @container_opts,
         opts
       )
 
@@ -529,15 +594,11 @@ defmodule JungleSpec do
 
     items_schema =
       union_types
-      |> Enum.map(&prepare_property_schema(module, title, name, &1, clear_opts_for_nested_types(opts)))
+      |> Enum.map(&prepare_property_schema(module, title, name, &1, keep_opts_for_nested_types(opts)))
       |> Enum.uniq()
 
     schema_map =
-      maybe_add_opts(
-        %{oneOf: items_schema},
-        [:description, :default],
-        opts
-      )
+      maybe_add_opts(%{oneOf: items_schema}, @container_opts, opts)
 
     struct(Schema, schema_map)
   end
@@ -549,11 +610,7 @@ defmodule JungleSpec do
     nullable = Keyword.get(opts, :nullable, false)
 
     schema_map =
-      maybe_add_opts(
-        %{type: type, nullable: nullable},
-        [:description, :default, :format, :pattern, :example, :enum],
-        opts
-      )
+      maybe_add_opts(%{type: type, nullable: nullable}, @passthrough_opts, opts)
 
     struct(Schema, schema_map)
   end
@@ -594,6 +651,92 @@ defmodule JungleSpec do
   end
 
   defp validate_opts!(name, type, opts) do
+    validate_known_opts!(name, opts, @property_opts)
+    validate_type_scoped_opts!(name, type, opts)
+    validate_enum!(name, type, opts)
+    validate_default!(name, type, opts)
+  end
+
+  defp validate_known_opts!(name, opts, known_opts) do
+    Enum.each(opts, fn {key, _value} -> validate_option_key!(name, key, known_opts) end)
+  end
+
+  defp validate_option_key!(name, key, known_opts) do
+    cond do
+      key in known_opts ->
+        :ok
+
+      key in @derived_schema_fields ->
+        raise ArgumentError,
+              "#{inspect(key)} cannot be given as an option for #{name}: JungleSpec sets it itself"
+
+      key in @object_only_opts ->
+        raise ArgumentError,
+              "#{inspect(key)} cannot be given as an option for #{name}: it is only supported by open_api_object"
+
+      true ->
+        raise ArgumentError, describe_unknown_option(name, key, known_opts)
+    end
+  end
+
+  defp describe_unknown_option(name, key, known_opts) do
+    message = "#{inspect(key)} is not a supported option for #{name}"
+
+    case find_closest_option(key, known_opts) do
+      nil -> message
+      closest -> message <> ". Did you mean #{inspect(closest)}?"
+    end
+  end
+
+  defp find_closest_option(key, known_opts) do
+    key_string = Atom.to_string(key)
+    scored_options = Enum.map(known_opts, &score_option(&1, key_string))
+    matches = Enum.filter(scored_options, fn {_option, distance} -> distance >= @suggestion_threshold end)
+
+    pick_closest_option(matches)
+  end
+
+  defp score_option(option, key_string) do
+    distance = String.jaro_distance(key_string, Atom.to_string(option))
+    {option, distance}
+  end
+
+  defp pick_closest_option([]), do: nil
+
+  defp pick_closest_option(matches) do
+    {option, _distance} = Enum.max_by(matches, fn {_option, distance} -> distance end)
+    option
+  end
+
+  defp validate_type_scoped_opts!(name, type, opts) do
+    allowed = list_allowed_opts(type)
+
+    Enum.each(opts, fn {key, _value} -> validate_type_scoped_opt!(name, type, key, allowed) end)
+  end
+
+  defp validate_type_scoped_opt!(_name, _type, key, _allowed) when key not in @type_scoped_opts, do: :ok
+
+  defp validate_type_scoped_opt!(name, type, key, allowed) do
+    if key not in allowed do
+      raise ArgumentError,
+            "#{inspect(key)} cannot be given as an option for #{name}: it does not apply to type #{inspect(type)}"
+    end
+  end
+
+  defp list_allowed_opts(type) when type in @numeric_types, do: @numeric_opts
+  defp list_allowed_opts(:string), do: @string_opts
+  defp list_allowed_opts(:object), do: @map_opts
+  defp list_allowed_opts({:array, item_type}), do: @array_opts ++ list_item_opts(item_type)
+  defp list_allowed_opts({:map, value_type}), do: @map_opts ++ list_item_opts(value_type)
+  defp list_allowed_opts(_type), do: []
+
+  # Only the options describing a single value travel to the items, so only those may be given for
+  # a collection. A collection nested in a collection cannot be constrained from the outside.
+  defp list_item_opts(type) do
+    Enum.filter(list_allowed_opts(type), &(&1 in @item_opts))
+  end
+
+  defp validate_enum!(name, type, opts) do
     if Keyword.has_key?(opts, :enum) do
       if type != :string do
         raise ArgumentError,
@@ -605,7 +748,9 @@ defmodule JungleSpec do
               "#{name} has values of invalid types in the enum option. They should be binaries"
       end
     end
+  end
 
+  defp validate_default!(name, type, opts) do
     if Keyword.has_key?(opts, :default) do
       if not (opts |> Keyword.get(:default) |> has_valid_type?(type)) do
         raise ArgumentError, "default value of #{name} does not match its type"
@@ -641,12 +786,12 @@ defmodule JungleSpec do
     Enum.all?(default, fn {key, value} -> is_binary(key) and has_valid_type?(value, expected_type) end)
   end
 
+  defp has_valid_type?(default, :object) when is_map(default), do: true
+
   defp has_valid_type?(_default, _expected_type), do: false
 
-  defp clear_opts_for_nested_types(opts) do
-    Enum.reduce([:nullable, :default, :description, :enum], opts, fn key, opts ->
-      Keyword.delete(opts, key)
-    end)
+  defp keep_opts_for_nested_types(opts) do
+    Keyword.take(opts, @nested_opts)
   end
 
   defp required_properties_names(properties) do

--- a/lib/jungle_spec.ex
+++ b/lib/jungle_spec.ex
@@ -203,7 +203,7 @@ defmodule JungleSpec do
   @field_by_option %Schema{}
                    |> Map.from_struct()
                    |> Map.keys()
-                   |> Map.new(&{OptionName.to_option(&1), &1})
+                   |> Map.new(fn schema_field -> {OptionName.to_option(schema_field), schema_field} end)
   @option_names Map.keys(@field_by_option)
 
   # Options interpreted by JungleSpec itself. They never reach the generated schema struct as
@@ -710,6 +710,7 @@ defmodule JungleSpec do
 
   defp score_option(option, key_string) do
     distance = String.jaro_distance(key_string, Atom.to_string(option))
+
     {option, distance}
   end
 

--- a/lib/jungle_spec.ex
+++ b/lib/jungle_spec.ex
@@ -200,7 +200,10 @@ defmodule JungleSpec do
 
   # Options are named the way Elixir names things and translated to the camelCased schema field
   # they set, so the `minLength` field of `OpenApiSpex.Schema` is given as `min_length`.
-  @field_by_option %Schema{} |> Map.from_struct() |> Map.keys() |> Map.new(&{OptionName.to_option(&1), &1})
+  @field_by_option %Schema{}
+                   |> Map.from_struct()
+                   |> Map.keys()
+                   |> Map.new(&{OptionName.to_option(&1), &1})
   @option_names Map.keys(@field_by_option)
 
   # Options interpreted by JungleSpec itself. They never reach the generated schema struct as

--- a/lib/jungle_spec.ex
+++ b/lib/jungle_spec.ex
@@ -200,7 +200,7 @@ defmodule JungleSpec do
 
   # Options are named the way Elixir names things and translated to the camelCased schema field
   # they set, so the `minLength` field of `OpenApiSpex.Schema` is given as `min_length`.
-  @field_by_option Map.new(Map.keys(Map.from_struct(%Schema{})), &{OptionName.to_option(&1), &1})
+  @field_by_option %Schema{} |> Map.from_struct() |> Map.keys() |> Map.new(&{OptionName.to_option(&1), &1})
   @option_names Map.keys(@field_by_option)
 
   # Options interpreted by JungleSpec itself. They never reach the generated schema struct as
@@ -829,7 +829,10 @@ defmodule JungleSpec do
 
   defp put_given_option(option, schema_map, opts) do
     if Keyword.has_key?(opts, option) do
-      Map.put(schema_map, Map.fetch!(@field_by_option, option), Keyword.get(opts, option))
+      schema_field = Map.fetch!(@field_by_option, option)
+      value = Keyword.get(opts, option)
+
+      Map.put(schema_map, schema_field, value)
     else
       schema_map
     end

--- a/lib/jungle_spec/option_name.ex
+++ b/lib/jungle_spec/option_name.ex
@@ -1,0 +1,19 @@
+defmodule JungleSpec.OptionName do
+  @moduledoc """
+  Translation between the option names JungleSpec accepts and the fields of `OpenApiSpex.Schema`.
+
+  Schema fields are camelCased, because that is how they are serialised into an OpenAPI document.
+  Options are written the way Elixir names things, so the `minLength` field is given as
+  `min_length` and the `x-validate` field as `x_validate`.
+  """
+
+  @doc """
+  Returns the option name under which a given `OpenApiSpex.Schema` field is accepted.
+  """
+  @spec to_option(atom()) :: atom()
+  def to_option(schema_field) do
+    underscored = schema_field |> Atom.to_string() |> Macro.underscore()
+
+    underscored |> String.replace("-", "_") |> String.to_atom()
+  end
+end

--- a/lib/jungle_spec/option_name.ex
+++ b/lib/jungle_spec/option_name.ex
@@ -8,7 +8,11 @@ defmodule JungleSpec.OptionName do
   """
 
   @doc """
-  Returns the option name under which a given `OpenApiSpex.Schema` field is accepted.
+  Translates a name into the spelling JungleSpec uses for options.
+
+  `minLength` becomes `min_length` and `x-validate` becomes `x_validate`; a name that is already
+  written that way is returned unchanged. Whether the resulting option is accepted for a given
+  macro and type is decided elsewhere.
   """
   @spec to_option(atom()) :: atom()
   def to_option(schema_field) do

--- a/lib/jungle_spec/option_name.ex
+++ b/lib/jungle_spec/option_name.ex
@@ -16,8 +16,10 @@ defmodule JungleSpec.OptionName do
   """
   @spec to_option(atom()) :: atom()
   def to_option(schema_field) do
-    underscored = schema_field |> Atom.to_string() |> Macro.underscore()
-
-    underscored |> String.replace("-", "_") |> String.to_atom()
+    schema_field
+    |> Atom.to_string()
+    |> Macro.underscore()
+    |> String.replace("-", "_")
+    |> String.to_atom()
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule JungleSpec.MixProject do
   def project do
     [
       app: :jungle_spec,
-      version: "0.1.1",
+      version: "0.2.0",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/jungle_spec_test.exs
+++ b/test/jungle_spec_test.exs
@@ -111,6 +111,14 @@ defmodule JungleSpecTest do
                    &define_mismatched_enum_schema/0
     end
 
+    test "every camelCased schema field is rejected with a usable message" do
+      camel_cased = Enum.filter(list_schema_fields(), &camel_cased?/1)
+      unhelpful = Enum.reject(camel_cased, &helpful_rejection?/1)
+
+      assert camel_cased != []
+      assert unhelpful == []
+    end
+
     test "a camelCased option name is rejected and points at the Elixir one" do
       assert_raise ArgumentError,
                    ~r/:minLength is not a supported option for slug\. Did you mean :min_length\?/,
@@ -146,6 +154,54 @@ defmodule JungleSpecTest do
       assert_raise ArgumentError,
                    ~r/:struct\? cannot be given as an option for OnlyObject: it is only supported by open_api_object/,
                    &define_object_only_option_schema/0
+    end
+  end
+
+  defp list_schema_fields do
+    Map.keys(Map.from_struct(%OpenApiSpex.Schema{}))
+  end
+
+  # Decided from the spelling alone, so that a regression in the translation removes coverage from
+  # nothing and instead makes the assertion below fail.
+  defp camel_cased?(schema_field) do
+    String.match?(Atom.to_string(schema_field), ~r/[A-Z-]/)
+  end
+
+  defp helpful_rejection?(schema_field) do
+    message = describe_rejection(schema_field)
+    option = JungleSpec.OptionName.to_option(schema_field)
+
+    String.contains?(message, "Did you mean #{inspect(option)}?") or
+      String.contains?(message, "sets it itself")
+  end
+
+  defp describe_rejection(schema_field) do
+    code = """
+    defmodule CamelCased#{System.unique_integer([:positive])} do
+      use JungleSpec
+
+      open_api_object "CamelCased" do
+        property :slug, :string, #{to_keyword_key(schema_field)} 1
+      end
+    end
+    """
+
+    try do
+      Code.compile_string(code)
+      "the option was accepted"
+    rescue
+      error in ArgumentError -> Exception.message(error)
+    end
+  end
+
+  # A name that is not a bare atom literal has to be quoted; quoting the others would warn.
+  defp to_keyword_key(schema_field) do
+    name = Atom.to_string(schema_field)
+
+    if String.match?(name, ~r/^[a-zA-Z_][a-zA-Z0-9_]*$/) do
+      "#{name}:"
+    else
+      ~s("#{name}":)
     end
   end
 

--- a/test/jungle_spec_test.exs
+++ b/test/jungle_spec_test.exs
@@ -111,6 +111,12 @@ defmodule JungleSpecTest do
                    &define_mismatched_enum_schema/0
     end
 
+    test "a camelCased option name is rejected and points at the Elixir one" do
+      assert_raise ArgumentError,
+                   ~r/:minLength is not a supported option for slug\. Did you mean :min_length\?/,
+                   &define_camel_case_option_schema/0
+    end
+
     test "an item option reaches the innermost schema of nested collections" do
       assert NestedJungle.schema().properties.grid.items.items.minLength == 2
     end
@@ -126,13 +132,13 @@ defmodule JungleSpecTest do
 
     test "a collection nested in a collection cannot be constrained from the outside" do
       assert_raise ArgumentError,
-                   ~r/:minProperties cannot be given as an option for buckets: it does not apply to type/,
+                   ~r/:min_properties cannot be given as an option for buckets: it does not apply to type/,
                    &define_nested_container_option_schema/0
     end
 
     test "an object level option that does not apply to objects raises" do
       assert_raise ArgumentError,
-                   ~r/:minLength cannot be given as an option for ObjectConstraint: it does not apply to type :object/,
+                   ~r/:min_length cannot be given as an option for ObjectConstraint: it does not apply to type :object/,
                    &define_object_constraint_schema/0
     end
 
@@ -178,7 +184,7 @@ defmodule JungleSpecTest do
       use JungleSpec
 
       open_api_object "NestedContainerOption" do
-        property :buckets, {:array, {:map, :string}}, minProperties: 1
+        property :buckets, {:array, {:map, :string}}, min_properties: 1
       end
     end
   end
@@ -203,6 +209,16 @@ defmodule JungleSpecTest do
     end
   end
 
+  defp define_camel_case_option_schema do
+    defmodule CamelCaseOption do
+      use JungleSpec
+
+      open_api_object "CamelCaseOption" do
+        property :slug, :string, minLength: 3
+      end
+    end
+  end
+
   defp define_object_enum_schema do
     defmodule ObjectEnum do
       use JungleSpec
@@ -215,7 +231,7 @@ defmodule JungleSpecTest do
     defmodule ObjectConstraint do
       use JungleSpec
 
-      open_api_object "ObjectConstraint", minLength: 3
+      open_api_object "ObjectConstraint", min_length: 3
     end
   end
 

--- a/test/jungle_spec_test.exs
+++ b/test/jungle_spec_test.exs
@@ -105,6 +105,11 @@ defmodule JungleSpecTest do
       assert NestedJungle.schema().properties.grid.items.items.minLength == 2
     end
 
+    test "open_api_type can be given without an option list" do
+      assert TwoArgJungle.schema().type == :string
+      assert TwoArgJungle.schema().title == "TwoArgJungle"
+    end
+
     test "an object level default reaches the schema" do
       assert NestedJungle.schema().default == %{"grid" => []}
     end

--- a/test/jungle_spec_test.exs
+++ b/test/jungle_spec_test.exs
@@ -95,10 +95,20 @@ defmodule JungleSpecTest do
                    &define_union_item_option_schema/0
     end
 
-    test "an object level enum is rejected the same way a property level one is" do
+    test "an object level enum is rejected" do
       assert_raise ArgumentError,
-                   ~r/enum option, but it can be provided only for string type/,
+                   ~r/:enum cannot be given as an option for ObjectEnum: it does not apply to type :object/,
                    &define_object_enum_schema/0
+    end
+
+    test "an enum is accepted for any scalar type, not only strings" do
+      assert ConstrainedJungle.schema().properties.rank.enum == [1, 2, 3]
+    end
+
+    test "enum values have to match the type they are given for" do
+      assert_raise ArgumentError,
+                   ~r/the enum values of rank do not all match its type :integer/,
+                   &define_mismatched_enum_schema/0
     end
 
     test "an item option reaches the innermost schema of nested collections" do
@@ -179,6 +189,16 @@ defmodule JungleSpecTest do
 
       open_api_object "UnionItemOption" do
         property :either, [:string, :integer], format: :uuid
+      end
+    end
+  end
+
+  defp define_mismatched_enum_schema do
+    defmodule MismatchedEnum do
+      use JungleSpec
+
+      open_api_object "MismatchedEnum" do
+        property :rank, :integer, enum: [1, "two"]
       end
     end
   end

--- a/test/jungle_spec_test.exs
+++ b/test/jungle_spec_test.exs
@@ -28,4 +28,177 @@ defmodule JungleSpecTest do
     type_str = types |> hd() |> elem(1) |> Code.Typespec.type_to_quoted() |> Macro.to_string()
     assert type_str == "t() :: %FileUpload{file: Plug.Upload.t(), metadata: %{optional(String.t()) => String.t()}}"
   end
+
+  describe "option contract" do
+    test "validation keywords reach the generated schema" do
+      properties = ConstrainedJungle.schema().properties
+
+      assert properties.page.minimum == 1
+      assert properties.page.maximum == 100
+      assert properties.slug.minLength == 3
+      assert properties.slug.maxLength == 30
+      assert properties.tags.minItems == 1
+    end
+
+    test "object level options reach the generated schema" do
+      assert ConstrainedJungle.schema().deprecated
+    end
+
+    test "options stay on the outer schema instead of leaking into the item schema" do
+      tags = ConstrainedJungle.schema().properties.tags
+
+      assert tags.example == ["red", "blue"]
+      assert tags.items.example == nil
+    end
+
+    test "an unknown option raises and suggests the closest supported one" do
+      assert_raise ArgumentError,
+                   ~r/:desciption is not a supported option for name\. Did you mean :description\?/,
+                   &define_misspelled_option_schema/0
+    end
+
+    test "an option JungleSpec sets itself raises" do
+      assert_raise ArgumentError,
+                   ~r/:type cannot be given as an option for name: JungleSpec sets it itself/,
+                   &define_derived_option_schema/0
+    end
+
+    test "a validation keyword that does not apply to the type raises" do
+      assert_raise ArgumentError,
+                   ~r/:minimum cannot be given as an option for name: it does not apply to type :string/,
+                   &define_mismatched_constraint_schema/0
+    end
+
+    test "item options describe the items of a collection, not the container" do
+      properties = ConstrainedJungle.schema().properties
+
+      assert properties.ids.items.format == :uuid
+      assert properties.ids.format == nil
+      assert properties.ids.minItems == 2
+      assert properties.codes.additionalProperties.minLength == 2
+      assert properties.codes.minProperties == 1
+      assert properties.codes.minLength == nil
+    end
+
+    test "passthrough reaches map and union schemas" do
+      properties = ConstrainedJungle.schema().properties
+
+      assert properties.codes.example == %{"a" => "bb"}
+      assert properties.codes.additionalProperties.example == nil
+      assert properties.either.description == "a number or a word"
+      assert properties.either.example == 5
+    end
+
+    test "an item option raises when the type has no single item to describe" do
+      assert_raise ArgumentError,
+                   ~r/:format cannot be given as an option for either: it does not apply to type/,
+                   &define_union_item_option_schema/0
+    end
+
+    test "an object level enum is rejected the same way a property level one is" do
+      assert_raise ArgumentError,
+                   ~r/enum option, but it can be provided only for string type/,
+                   &define_object_enum_schema/0
+    end
+
+    test "an item option reaches the innermost schema of nested collections" do
+      assert NestedJungle.schema().properties.grid.items.items.minLength == 2
+    end
+
+    test "an object level default reaches the schema" do
+      assert NestedJungle.schema().default == %{"grid" => []}
+    end
+
+    test "a collection nested in a collection cannot be constrained from the outside" do
+      assert_raise ArgumentError,
+                   ~r/:minProperties cannot be given as an option for buckets: it does not apply to type/,
+                   &define_nested_container_option_schema/0
+    end
+
+    test "an object level option that does not apply to objects raises" do
+      assert_raise ArgumentError,
+                   ~r/:minLength cannot be given as an option for ObjectConstraint: it does not apply to type :object/,
+                   &define_object_constraint_schema/0
+    end
+
+    test "an object only option raises when given to open_api_type" do
+      assert_raise ArgumentError,
+                   ~r/:struct\? cannot be given as an option for OnlyObject: it is only supported by open_api_object/,
+                   &define_object_only_option_schema/0
+    end
+  end
+
+  defp define_misspelled_option_schema do
+    defmodule MisspelledOption do
+      use JungleSpec
+
+      open_api_object "MisspelledOption" do
+        property :name, :string, desciption: "typo"
+      end
+    end
+  end
+
+  defp define_derived_option_schema do
+    defmodule DerivedOption do
+      use JungleSpec
+
+      open_api_object "DerivedOption" do
+        property :name, :string, type: :uuid
+      end
+    end
+  end
+
+  defp define_mismatched_constraint_schema do
+    defmodule MismatchedConstraint do
+      use JungleSpec
+
+      open_api_object "MismatchedConstraint" do
+        property :name, :string, minimum: 1
+      end
+    end
+  end
+
+  defp define_nested_container_option_schema do
+    defmodule NestedContainerOption do
+      use JungleSpec
+
+      open_api_object "NestedContainerOption" do
+        property :buckets, {:array, {:map, :string}}, minProperties: 1
+      end
+    end
+  end
+
+  defp define_union_item_option_schema do
+    defmodule UnionItemOption do
+      use JungleSpec
+
+      open_api_object "UnionItemOption" do
+        property :either, [:string, :integer], format: :uuid
+      end
+    end
+  end
+
+  defp define_object_enum_schema do
+    defmodule ObjectEnum do
+      use JungleSpec
+
+      open_api_object "ObjectEnum", enum: [1, 2]
+    end
+  end
+
+  defp define_object_constraint_schema do
+    defmodule ObjectConstraint do
+      use JungleSpec
+
+      open_api_object "ObjectConstraint", minLength: 3
+    end
+  end
+
+  defp define_object_only_option_schema do
+    defmodule ObjectOnlyOption do
+      use JungleSpec
+
+      open_api_type "OnlyObject", :string, struct?: false
+    end
+  end
 end

--- a/test/jungle_spec_test.exs
+++ b/test/jungle_spec_test.exs
@@ -162,13 +162,17 @@ defmodule JungleSpecTest do
   end
 
   defp list_schema_fields do
-    Map.keys(Map.from_struct(%OpenApiSpex.Schema{}))
+    %OpenApiSpex.Schema{}
+    |> Map.from_struct()
+    |> Map.keys()
   end
 
   # Decided from the spelling alone, so that a regression in the translation removes coverage from
   # nothing and instead makes the assertion below fail.
   defp camel_cased?(schema_field) do
-    String.match?(Atom.to_string(schema_field), ~r/[A-Z-]/)
+    schema_field
+    |> Atom.to_string()
+    |> String.match?(~r/[A-Z-]/)
   end
 
   defp helpful_rejection?(schema_field) do

--- a/test/jungle_spec_test.exs
+++ b/test/jungle_spec_test.exs
@@ -15,9 +15,12 @@ defmodule JungleSpecTest do
 
   test "Old and new Type schemas are the same" do
     id_new = IDJungle.schema()
-    id_old = IDSpex.schema()
+    id_old = %{IDSpex.schema() | title: "IDJungle"}
 
-    assert id_new == %{id_old | title: "IDJungle"}
+    # Regex structs built in different modules do not compare equal on Elixir 1.20, so the
+    # pattern is compared through its source.
+    assert id_new.pattern.source == id_old.pattern.source
+    assert %{id_new | pattern: nil} == %{id_old | pattern: nil}
   end
 
   test "String with :binary format becomes Plug.Upload.t()" do

--- a/test/jungle_spec_test.exs
+++ b/test/jungle_spec_test.exs
@@ -101,8 +101,12 @@ defmodule JungleSpecTest do
                    &define_object_enum_schema/0
     end
 
-    test "an enum is accepted for any scalar type, not only strings" do
-      assert ConstrainedJungle.schema().properties.rank.enum == [1, 2, 3]
+    test "an enum is accepted for every scalar type" do
+      properties = ConstrainedJungle.schema().properties
+
+      assert properties.rank.enum == [1, 2, 3]
+      assert properties.score.enum == [1.5, 2.5]
+      assert properties.kind.enum == ["first", "second"]
     end
 
     test "enum values have to match the type they are given for" do

--- a/test_lib/constrained_jungle.ex
+++ b/test_lib/constrained_jungle.ex
@@ -9,5 +9,7 @@ defmodule ConstrainedJungle do
     property :codes, {:map, :string}, min_length: 2, min_properties: 1, example: %{"a" => "bb"}
     property :either, [:integer, :string], description: "a number or a word", example: 5
     property :rank, :integer, enum: [1, 2, 3]
+    property :score, :number, enum: [1.5, 2.5]
+    property :kind, :string, enum: ["first", "second"]
   end
 end

--- a/test_lib/constrained_jungle.ex
+++ b/test_lib/constrained_jungle.ex
@@ -8,5 +8,6 @@ defmodule ConstrainedJungle do
     property :ids, {:array, :string}, format: :uuid, minItems: 2
     property :codes, {:map, :string}, minLength: 2, minProperties: 1, example: %{"a" => "bb"}
     property :either, [:integer, :string], description: "a number or a word", example: 5
+    property :rank, :integer, enum: [1, 2, 3]
   end
 end

--- a/test_lib/constrained_jungle.ex
+++ b/test_lib/constrained_jungle.ex
@@ -1,0 +1,12 @@
+defmodule ConstrainedJungle do
+  use JungleSpec
+
+  open_api_object "ConstrainedJungle", deprecated: true do
+    property :page, :integer, minimum: 1, maximum: 100
+    property :slug, :string, minLength: 3, maxLength: 30
+    property :tags, {:array, :string}, minItems: 1, example: ["red", "blue"]
+    property :ids, {:array, :string}, format: :uuid, minItems: 2
+    property :codes, {:map, :string}, minLength: 2, minProperties: 1, example: %{"a" => "bb"}
+    property :either, [:integer, :string], description: "a number or a word", example: 5
+  end
+end

--- a/test_lib/constrained_jungle.ex
+++ b/test_lib/constrained_jungle.ex
@@ -3,10 +3,10 @@ defmodule ConstrainedJungle do
 
   open_api_object "ConstrainedJungle", deprecated: true do
     property :page, :integer, minimum: 1, maximum: 100
-    property :slug, :string, minLength: 3, maxLength: 30
-    property :tags, {:array, :string}, minItems: 1, example: ["red", "blue"]
-    property :ids, {:array, :string}, format: :uuid, minItems: 2
-    property :codes, {:map, :string}, minLength: 2, minProperties: 1, example: %{"a" => "bb"}
+    property :slug, :string, min_length: 3, max_length: 30
+    property :tags, {:array, :string}, min_items: 1, example: ["red", "blue"]
+    property :ids, {:array, :string}, format: :uuid, min_items: 2
+    property :codes, {:map, :string}, min_length: 2, min_properties: 1, example: %{"a" => "bb"}
     property :either, [:integer, :string], description: "a number or a word", example: 5
     property :rank, :integer, enum: [1, 2, 3]
   end

--- a/test_lib/id_jungle.ex
+++ b/test_lib/id_jungle.ex
@@ -5,6 +5,5 @@ defmodule IDJungle do
     nullable: true,
     format: :uuid,
     pattern: ~r/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/,
-    example: "193202fc-ab55-4824-8ec8-5bef1201d9eb",
-    struct?: false
+    example: "193202fc-ab55-4824-8ec8-5bef1201d9eb"
 end

--- a/test_lib/nested_jungle.ex
+++ b/test_lib/nested_jungle.ex
@@ -2,6 +2,6 @@ defmodule NestedJungle do
   use JungleSpec
 
   open_api_object "NestedJungle", default: %{"grid" => []} do
-    property :grid, {:array, {:array, :string}}, minLength: 2, minItems: 1
+    property :grid, {:array, {:array, :string}}, min_length: 2, min_items: 1
   end
 end

--- a/test_lib/nested_jungle.ex
+++ b/test_lib/nested_jungle.ex
@@ -1,0 +1,7 @@
+defmodule NestedJungle do
+  use JungleSpec
+
+  open_api_object "NestedJungle", default: %{"grid" => []} do
+    property :grid, {:array, {:array, :string}}, minLength: 2, minItems: 1
+  end
+end

--- a/test_lib/two_arg_jungle.ex
+++ b/test_lib/two_arg_jungle.ex
@@ -1,0 +1,5 @@
+defmodule TwoArgJungle do
+  use JungleSpec
+
+  open_api_type "TwoArgJungle", :string
+end


### PR DESCRIPTION
## The problem

Options given to the macros were copied into the generated `%OpenApiSpex.Schema{}` through
hardcoded allowlists, and option keys were never validated. Anything outside those lists was
discarded without an error or a warning, so a schema compiled cleanly while the constraint never
reached the published document:

```elixir
property :page, :integer, minimum: 1, maximum: 100   # both dropped
property :name, :string, desciption: "typo"          # dropped, no error
property :id, :string, type: :uuid                   # dropped; :format was meant
```

The same applied to every validation keyword OpenAPI defines — `minLength`, `maxItems`,
`uniqueItems`, `multipleOf` and the rest — and to the documentation keywords `deprecated`,
`readOnly`, `writeOnly` and `externalDocs`.

## What changes

The accepted option set is now derived from `OpenApiSpex.Schema` instead of being hardcoded, and
keys are validated while the schema is compiled. Options fall into three groups:

* `:inline`, `:nullable`, `:required`, `:extends` and `:struct?` are interpreted by JungleSpec
  itself
* the fields JungleSpec sets from the positional type argument — `:type`, `:items`, `:oneOf`,
  `:title`, `:"x-struct"` and friends — cannot be given and raise if they are
* every other `OpenApiSpex.Schema` field is copied into the generated schema verbatim

An unknown key raises with a suggestion:

```
** (ArgumentError) :desciption is not a supported option for name. Did you mean :description?
```

Options are also rejected for types they do not apply to, so `minimum` on a `:string` or `format`
on a union now fails instead of ending up in the document where nothing reads it.

Options describing a single value apply to the items of a collection. `{:array, type}` and
`{:map, type}` accept whatever `type` accepts and hand it to the item schema:

```elixir
property :ids, {:array, :string}, format: :uuid, minItems: 1
# minItems on the array, format on its items
```

Every other option describes the schema it is given for. Previously keys such as `example` were
forwarded to the item schema instead of staying on the container.

## Breaking changes

Anything that compiled before and carried an unsupported or misspelled key now fails to compile.
That is the point of the release: those keys were doing nothing. The compiler names each one and
suggests the nearest valid option, so the migration is mechanical.

Two behavioural changes are worth calling out because they do not produce a compile error:

* validation keywords that were silently dropped now reach the document, and `OpenApiSpex`
  enforces most of them while casting. A `minimum` that never applied will start rejecting
  requests it used to accept.
* `example`, `format` and `pattern` given for a collection change position. `example` now stays on
  the container; `format` and `pattern` still describe the items, as before.

Object level options are validated the same way property level ones are, so an object `enum`
raises and an object `default` has to be a map.

## Also included, not breaking

`open_api_type "Title", :string` failed with `undefined function open_api_type/2` and needed an
explicit empty option list. `property/2` and `additional_properties/1` were reachable only inside
an `open_api_object` block, which imports the module unrestricted. The import list in `__using__`
now matches the arities `.formatter.exs` has always declared.

## Known limitation

A property typed by another module renders as a bare `$ref`, which has nowhere to carry the extra
fields, so only `:nullable` and `:inline` take effect there. The remaining options are still
dropped. Both the docs and the changelog state this explicitly; giving the reference a wrapper so
it can carry a description is a separate change.

## Notes

Two pre-existing defects surfaced while working on this and are filed separately: #8 and #9. Both
correspond to compiler warnings that already existed on `main` and are untouched here.

The six commits are independent and each keeps the suite green on its own. The first repairs a
test that was already failing on `main`: two `~r//` literals with the same source no longer
compare equal when built in separate modules on Elixir 1.20.

Every behavioural change is covered by a test that fails against the previous implementation —
19 of the 35 tests fail when `lib/jungle_spec.ex` is reverted.
